### PR TITLE
大佬，发现您的项目引入了org.springframework.security:spring-security-core@5.0.1.RELEASE组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.itheima</groupId>
@@ -17,7 +13,7 @@
     <mysql.version>5.1.6</mysql.version>
     <mybatis.version>3.4.5</mybatis.version>
 
-    <spring.security.version>5.0.1.RELEASE</spring.security.version>
+    <spring.security.version>5.2.9.RELEASE</spring.security.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Vmware VMware Spring Security 权限许可和访问控制问题漏洞
缺陷组件：org.springframework.security:spring-security-core@5.0.1.RELEASE
漏洞编号：CVE-2021-22112
漏洞描述：Vmware VMware Spring Security是美国威睿（Vmware）公司的一套为基于Spring的应用程序提供说明性安全保护的安全框架。
VMware Spring Security 中存在权限许可和访问控制问题漏洞。该漏洞源于攻击者可以通过Spring Security的多个SecurityContext更改绕过限制，以提升其权限。以下产品及版本受到影响：Spring Security 5.4.0 至 5.4.3 版本, Spring Security 5.3.0.RELEASE 至 5.3.7.RELEASE 版本, Spring Security 5.2.0.RELEASE 至 5.2.8.RELEASE 版本。
影响范围：(∞, 5.2.9.RELEASE)
最小修复版本：5.2.9.RELEASE
缺陷组件引入路径：com.itheima:ssm@1.0-SNAPSHOT->org.springframework.security:spring-security-core@5.0.1.RELEASE
```
另外我运行这个项目时，IDE的安全插件提示还有92个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pea02c